### PR TITLE
Implement optional data arg

### DIFF
--- a/R/cv.penlmabc.R
+++ b/R/cv.penlmabc.R
@@ -101,6 +101,9 @@ cv.penlmabc = function(formula,
 		stop('type must be "ridge" or "lasso"')
 	}
 
+	# Fill in the data argument with stats::model.frame
+	data <- model_frame(formula = formula, data = data)
+
 	# Get constraint matrix:
 	Con = getConstraints(formula, data, props)
 	m = nrow(Con)

--- a/R/cv.penlmabc.R
+++ b/R/cv.penlmabc.R
@@ -96,13 +96,13 @@ cv.penlmabc = function(formula,
 										props = NULL,
 										plot = FALSE) {
 
+	# Fill in the data argument with stats::model.frame
+	data <- model_frame(formula = formula, data = data)
+
 	# Quick check: ridge or lasso
 	if(!(type == 'ridge' | type == 'lasso')){
 		stop('type must be "ridge" or "lasso"')
 	}
-
-	# Fill in the data argument with stats::model.frame
-	data <- model_frame(formula = formula, data = data)
 
 	# Get constraint matrix:
 	Con = getConstraints(formula, data, props)

--- a/R/glmabc.R
+++ b/R/glmabc.R
@@ -52,6 +52,9 @@ glmabc = function(formula, family = stats::gaussian, data, ..., props = NULL){
        consider a different formula statement')
 	}
 
+	# Fill in the data argument with stats::model.frame
+	data <- model_frame(formula = formula, data = data)
+
 	# Compute the constraint matrix:
 	Con = getConstraints(formula, data, props = props)
 

--- a/R/glmabc.R
+++ b/R/glmabc.R
@@ -41,6 +41,9 @@
 #' @export
 glmabc = function(formula, family = stats::gaussian, data, ..., props = NULL){
 
+	# Fill in the data argument with stats::model.frame
+	data <- model_frame(formula = formula, data = data)
+
 	# Usual glm fit: this is a nice baseline
 	fit0 = stats::glm(formula = formula,
 										family = family,
@@ -51,9 +54,6 @@ glmabc = function(formula, family = stats::gaussian, data, ..., props = NULL){
 		stop('NAs found in the OLS estimators;
        consider a different formula statement')
 	}
-
-	# Fill in the data argument with stats::model.frame
-	data <- model_frame(formula = formula, data = data)
 
 	# Compute the constraint matrix:
 	Con = getConstraints(formula, data, props = props)

--- a/R/lmabc.R
+++ b/R/lmabc.R
@@ -92,6 +92,9 @@
 #' @export
 lmabc = function(formula, data, ..., props = NULL){
 
+	# Fill in the data argument with stats::model.frame
+	data <- model_frame(formula = formula, data = data)
+
 	# Usual fit: this is a nice baseline
 	fit0 = lm(formula = formula,
 						data = data, ...)
@@ -101,9 +104,6 @@ lmabc = function(formula, data, ..., props = NULL){
 		stop('NAs found in the OLS estimators;
        consider a different formula statement')
 	}
-
-	# Fill in the data argument with stats::model.frame
-	data <- model_frame(formula = formula, data = data)
 
 	# Compute the constraint matrix:
 	Con = getConstraints(formula, data, props = props)

--- a/R/lmabc.R
+++ b/R/lmabc.R
@@ -102,6 +102,9 @@ lmabc = function(formula, data, ..., props = NULL){
        consider a different formula statement')
 	}
 
+	# Fill in the data argument with stats::model.frame
+	data <- model_frame(formula = formula, data = data)
+
 	# Compute the constraint matrix:
 	Con = getConstraints(formula, data, props = props)
 

--- a/R/lmabc.R
+++ b/R/lmabc.R
@@ -94,7 +94,7 @@ lmabc = function(formula, data, ..., props = NULL){
 
 	# Usual fit: this is a nice baseline
 	fit0 = lm(formula = formula,
-						data  = data, ...)
+						data = data, ...)
 
 	# Check:
 	if(any(is.na(coef(fit0)))){

--- a/R/model_frame.R
+++ b/R/model_frame.R
@@ -20,7 +20,7 @@ model_frame <- function(formula, data) {
 	mf[[1L]] <- quote(stats::model.frame)
 
 	# call stats::model.frame
-	mf <- eval(mf, parent.frame())
+	mf <- eval(mf, parent.frame(n = 2L))
 
 	# remove "terms" attribute to avoid confusion
 	attr(mf, "terms") <- NULL

--- a/R/model_frame.R
+++ b/R/model_frame.R
@@ -1,0 +1,10 @@
+model_frame <- function(formula, data) {
+	mf <- match.call(call = sys.call(which = -1))
+	m <- match(c("formula", "data"), names(mf), 0L)
+	mf <- mf[c(1L, m)]
+	mf$drop.unused.levels <- TRUE
+	mf[[1L]] <- quote(stats::model.frame)
+	mf <- eval(mf, parent.frame())
+	attr(mf, "terms") <- NULL
+	mf
+}

--- a/R/model_frame.R
+++ b/R/model_frame.R
@@ -1,3 +1,14 @@
+#' Wrapper for model.frame
+#'
+#' `model.frame` returns a data.frame object for use in [lmabc()] and similar functions.
+#' It reimplements the first few lines of [lm()] to properly format the `formula` and `data` parameters.
+#' If only `formula` is passed, all variables must be vectors in the environment.
+#' If `formula` and `data` are passed, variables are first pulled from `data`, then filled from the environment.
+#'
+#' @param formula formula object
+#' @param data data.frame object
+#'
+#' @return a data.frame with the variables in `formula`
 model_frame <- function(formula, data) {
 	mf <- match.call(call = sys.call(which = -1))
 	m <- match(c("formula", "data"), names(mf), 0L)

--- a/R/model_frame.R
+++ b/R/model_frame.R
@@ -10,12 +10,20 @@
 #'
 #' @return a data.frame with the variables in `formula`
 model_frame <- function(formula, data) {
+	# set up call
 	mf <- match.call(call = sys.call(which = -1))
 	m <- match(c("formula", "data"), names(mf), 0L)
 	mf <- mf[c(1L, m)]
 	mf$drop.unused.levels <- TRUE
+
+	# change function to stats::model.frame
 	mf[[1L]] <- quote(stats::model.frame)
+
+	# call stats::model.frame
 	mf <- eval(mf, parent.frame())
+
+	# remove "terms" attribute to avoid confusion
 	attr(mf, "terms") <- NULL
+
 	mf
 }


### PR DESCRIPTION
I implemented the `model_frame` function to roughly copy functionality in `lm`. Basically, it calls `stats::model.frame` and returns a data.frame with the following criteria:

- If only `formula` is passed, all variables must be vectors in the environment.
- If `formula` and `data` are passed, variables are first pulled from `data`, then filled from the environment.

This pull request is a DRAFT because I need to add corresponding unit tests.