### PR TITLE
Reject `props` if there is a categorical-categorical interaction

### DIFF
--- a/R/getConstraints.R
+++ b/R/getConstraints.R
@@ -73,11 +73,15 @@ getConstraints = function(formula, data, props = NULL){
 
 		# Compute the ABCs:
 		if(is.null(props)){
+			empirical_props <- TRUE
+
 			# Categorical proportions:
 			pi_hat = lapply(cdat, function(k){
 				sapply(levels(k), function(g) mean(k==g))}
 			)
 		} else {
+			empirical_props <- FALSE
+
 			# Check that props is proper:
 			if(any(is.na(match(cnames, names(props))))){
 				stop('props must be a named list with an entry for each named categorical variable in the model')
@@ -103,6 +107,10 @@ getConstraints = function(formula, data, props = NULL){
 			covar)
 		inds_catcat = inds_catcat[!is.na(inds_catcat)]
 		if(length(inds_catcat) > 0){
+			if (!empirical_props) {
+				stop("Custom proportions with categorical-categorical interactions is not currently supported. Leave `props` blank (or set to `NULL`) to use the empirical proportions.")
+			}
+
 			covar_all = covar; covar = covar[-inds_catcat]
 			terms_mx <- terms_mx[,-inds_catcat]
 		}

--- a/R/getConstraints.R
+++ b/R/getConstraints.R
@@ -73,15 +73,11 @@ getConstraints = function(formula, data, props = NULL){
 
 		# Compute the ABCs:
 		if(is.null(props)){
-			empirical_props <- TRUE
-
 			# Categorical proportions:
 			pi_hat = lapply(cdat, function(k){
 				sapply(levels(k), function(g) mean(k==g))}
 			)
 		} else {
-			empirical_props <- FALSE
-
 			# Check that props is proper:
 			if(any(is.na(match(cnames, names(props))))){
 				stop('props must be a named list with an entry for each named categorical variable in the model')
@@ -107,7 +103,7 @@ getConstraints = function(formula, data, props = NULL){
 			covar)
 		inds_catcat = inds_catcat[!is.na(inds_catcat)]
 		if(length(inds_catcat) > 0){
-			if (!empirical_props) {
+			if (!is.null(props)) {
 				stop("Custom proportions with categorical-categorical interactions is not currently supported. Leave `props` blank (or set to `NULL`) to use the empirical proportions.")
 			}
 

--- a/tests/testthat/helper-lmabc.R
+++ b/tests/testthat/helper-lmabc.R
@@ -1,4 +1,4 @@
-helper_fitted <- function(f, df) {
+helper_fitted <- function(f, df, props = NULL) {
 	all_terms <- attr(terms(f), "term.labels")[which(attr(terms(f), "order")==1)]
 	df_used <- df[,all_terms]
 	factor_terms <- which(sapply(df_used, is.factor))
@@ -15,7 +15,7 @@ helper_fitted <- function(f, df) {
 													 											   stats::contrasts,
 													 											   contrasts=FALSE))
 
-	coefs <- as.matrix(coef(lmabc(f, df)))
+	coefs <- as.matrix(coef(lmabc(f, df, props = props)))
 	X <- as.matrix(mm)
 	(X %*% coefs)[,1]
 }

--- a/tests/testthat/test-lmabc.R
+++ b/tests/testthat/test-lmabc.R
@@ -18,6 +18,25 @@ test_that("lmabc does not have class 'lm' with some categoricals", {
 	expect_failure(expect_s3_class(lmabc(f, df), "lm"))
 })
 
+test_that("lmabc props argument works without cat-cat interactions", {
+	f <- f_contY_contX.catX
+	props <- list(
+		"cyl" = c("4" = 0.371, "6" = 0.244, "8" = 0.385),
+		"gear" = c("3" = 0.458, "4" = 0.397, "5" = 0.145),
+		"carb" = c("1" = 0.230, "2" = 0.307, "3" = 0.090, "4" = 0.322, "6" = 0.022, "8" = 0.029)
+	)
+	expect_equal(helper_fitted(f, df, props = props), lm(f, df)$fitted.values)
+})
+
+test_that("lmabc rejects supplied props with cat-cat interactions", {
+	f <- f_contY_catX.catX
+	props <- list(
+		"cyl" = c("4" = 0.371, "6" = 0.244, "8" = 0.385),
+		"gear" = c("3" = 0.458, "4" = 0.397, "5" = 0.145)
+	)
+	expect_error(helper_fitted(f, df, props = props))
+})
+
 test_that("lmabc works with f_contY_contX", {
 	f <- f_contY_contX
 	expect_equal(helper_fitted(f, df), lm(f, df)$fitted.values)


### PR DESCRIPTION
I added a conditional statement to `getConstraints.R`. If there are categorical-categorical interactions, I check that the `props` argument is NULL. If it is NULL, then earlier in the function we set `pi_hat` to the empirical proportions, so we are good to go. If it is not NULL, the code throws an error.

I also added two corresponding tests to `test-lmabc.R`. At a later time we should develop a complete test suite for `getConstraints.R` and `getFullDesign.R`, and these two tests should be just a starting point in the eventual `test-getConstraints.R` file.

For now, the two simple tests pass, so I think we should be good to close this issue.