### PR TITLE
Return props in `getConstraints`

### DIFF
--- a/R/getConstraints.R
+++ b/R/getConstraints.R
@@ -190,7 +190,12 @@ getConstraints = function(formula, data, props = NULL){
 			Con = rbind(Con, Con_cat)
 		}
 
-	} else Con = NULL # no factor variables
+		attr(Con, "pi_hat") <- pi_hat
+
+	} else {
+		Con <- NULL  # no factor variables
+		attr(Con, "pi_hat") <- props
+	}
 
 	return(Con)
 }

--- a/R/getConstraints.R
+++ b/R/getConstraints.R
@@ -194,7 +194,6 @@ getConstraints = function(formula, data, props = NULL){
 
 	} else {
 		Con <- NULL  # no factor variables
-		attr(Con, "pi_hat") <- props
 	}
 
 	return(Con)

--- a/R/glmabc.R
+++ b/R/glmabc.R
@@ -119,6 +119,7 @@ glmabc = function(formula, family = stats::gaussian, data, ..., props = NULL){
 		fit$glm = fit0 #  store the original object
 		fit$X = X # store the full design matrix
 		fit$Con = Con # store the constraint matrix
+		fit$pi_hat <- attr(Con, "pi_hat")  # story the proportions
 		fit$coefficients = beta_con # coefficient estimates
 		fit$cov.unscaled = cov.unscaled_con # covariance matrix
 		#fit$sigma = sigma_hat # estimated standard deviation

--- a/R/glmabc.R
+++ b/R/glmabc.R
@@ -59,6 +59,8 @@ glmabc = function(formula, family = stats::gaussian, data, ..., props = NULL){
 		# No categorical variables, so no constraints
 		return(fit0) # return the lm object
 	} else {
+		pi_hat <- attr(Con, "pi_hat")
+
 		# Incorporate the constraints
 
 		# Compute the full design matrix:

--- a/R/lmabc.R
+++ b/R/lmabc.R
@@ -178,6 +178,7 @@ lmabc = function(formula, data, ..., props = NULL){
 	fit$lm = fit0 #  store the original object
 	fit$X = X # store the full design matrix
 	fit$Con = Con # store the constraint matrix
+	fit$pi_hat <- attr(Con, "pi_hat")  # story the proportions
 	fit$coefficients = beta_con # coefficient estimates
 	fit$cov.unscaled = cov.unscaled_con # covariance matrix
 	fit$sigma = sigma_hat # estimated standard deviation

--- a/R/lmabc.R
+++ b/R/lmabc.R
@@ -117,7 +117,12 @@ lmabc = function(formula, data, ..., props = NULL){
 		beta_con <- coef(fit0_centered)
 		cov.unscaled_con <- vcov(fit0_centered)
 		sigma_hat <- sigma(fit0_centered)
+		pi_hat <- props
 	} else {
+		# save pi_hat
+
+		pi_hat <- attr(Con, "pi_hat")
+
 		# Incorporate the constraints
 
 		# Compute the full design matrix:
@@ -178,7 +183,7 @@ lmabc = function(formula, data, ..., props = NULL){
 	fit$lm = fit0 #  store the original object
 	fit$X = X # store the full design matrix
 	fit$Con = Con # store the constraint matrix
-	fit$pi_hat <- attr(Con, "pi_hat")  # story the proportions
+	fit$pi_hat <- pi_hat  # story the proportions
 	fit$coefficients = beta_con # coefficient estimates
 	fit$cov.unscaled = cov.unscaled_con # covariance matrix
 	fit$sigma = sigma_hat # estimated standard deviation

--- a/tests/testthat/test-lmabc.R
+++ b/tests/testthat/test-lmabc.R
@@ -52,3 +52,17 @@ test_that("lmabc works with f_contY_all", {
 	f <- f_contY_all
 	expect_equal(helper_fitted(f, df), lm(f, df)$fitted.values)
 })
+
+test_that("lmabc returns the correct pi_hat vector without specifying", {
+	f <- f_contY_contX.catX
+	expect_equal(lmabc(f, df)$pi_hat,
+							 list("cyl" = sapply(levels(df$cyl),
+							 										 function(g) mean(df$cyl == g))))
+})
+
+test_that("lmabc returns the correct pi_hat vector with custom props", {
+	f <- f_contY_contX.catX
+	props <- list("cyl" = c("4" = 0.9, "6" = 0.05, "8" = 0.05))
+	expect_equal(lmabc(f, df, props = props)$pi_hat,
+							 props)
+})

--- a/tests/testthat/test-lmabc.R
+++ b/tests/testthat/test-lmabc.R
@@ -66,3 +66,15 @@ test_that("lmabc returns the correct pi_hat vector with custom props", {
 	expect_equal(lmabc(f, df, props = props)$pi_hat,
 							 props)
 })
+
+test_that("lmabc returns NULL pi_hat vector with no cat, default props", {
+	f <- f_contY_contX
+	expect_null(lmabc(f, df)$pi_hat)
+})
+
+test_that("lmabc returns given pi_hat vector with no cat, custom props", {
+	f <- f_contY_contX
+	props <- list("blah" = 1)
+	expect_equal(lmabc(f, df, props = props)$pi_hat,
+							 props)
+})


### PR DESCRIPTION
I added `props` as an attribute to the `Con` matrix if it exists. If it's NULL, then the lmabc object's `pi_hat` element will be the `props` passed to `lmabc()`, which is by default NULL.

I also added the `props` output to `glmabc()`, though the current output from `glmabc()` if `Con` is NULL is the underlying `glm` object. I'll introduce an issue to change this. We need to consistently return a `glmabc` object, or we can break any pipelines that depend on object class.

I added a few more tests. I really should make a specific test file for `getConstraints()`!