### PR TITLE
Always return class "glmabc"

### DIFF
--- a/R/glmabc.R
+++ b/R/glmabc.R
@@ -60,7 +60,14 @@ glmabc = function(formula, family = stats::gaussian, data, ..., props = NULL){
 
 	if(is.null(Con)){
 		# No categorical variables, so no constraints
-		return(fit0) # return the lm object
+		X = getFullDesign(formula = formula,
+											data = data,
+											center = TRUE)
+
+		fit0_centered <- glm(y ~ X, family = family)
+		beta_con <- coef(fit0_centered)
+		cov.unscaled_con <- vcov(fit0_centered)
+		pi_hat <- props
 	} else {
 		pi_hat <- attr(Con, "pi_hat")
 

--- a/R/glmabc.R
+++ b/R/glmabc.R
@@ -67,6 +67,7 @@ glmabc = function(formula, family = stats::gaussian, data, props = NULL){
 
 		fit0_centered <- glm(y ~ X, family = family)
 		beta_con <- coef(fit0_centered)
+		names(beta_con) <- c("(Intercept)", colnames(X))
 		cov.unscaled_con <- vcov(fit0_centered)
 		pi_hat <- props
 	} else {

--- a/R/glmabc.R
+++ b/R/glmabc.R
@@ -60,9 +60,10 @@ glmabc = function(formula, family = stats::gaussian, data, props = NULL){
 
 	if(is.null(Con)){
 		# No categorical variables, so no constraints
-		X = getFullDesign(formula = formula,
-											data = data,
-											center = TRUE)
+		y <- data[[formula[[2]]]]
+		X <- getFullDesign(formula = formula,
+											 data = data,
+											 center = TRUE)[,-1, drop = FALSE]
 
 		fit0_centered <- glm(y ~ X, family = family)
 		beta_con <- coef(fit0_centered)

--- a/R/glmabc.R
+++ b/R/glmabc.R
@@ -117,20 +117,20 @@ glmabc = function(formula, family = stats::gaussian, data, ..., props = NULL){
 		}
 		#sigma_hat = summary(fit_con)$sigma # error SD
 		#^this is not going to work for glm, summary.glm does not have a sigma component
-
-		# New class:
-		fit = fit0;  attr(fit, 'class') = c('glmabc', 'lmabc')
-		fit$call = match.call()  # store the function call
-		fit$glm = fit0 #  store the original object
-		fit$X = X # store the full design matrix
-		fit$Con = Con # store the constraint matrix
-		fit$pi_hat <- attr(Con, "pi_hat")  # story the proportions
-		fit$coefficients = beta_con # coefficient estimates
-		fit$cov.unscaled = cov.unscaled_con # covariance matrix
-		#fit$sigma = sigma_hat # estimated standard deviation
-		# fit$residuals # already there
-		#ADD: call
-
-		return(fit) # return the glmabc object
 	}
+
+	# New class:
+	fit = fit0;  attr(fit, 'class') = c('glmabc', 'lmabc')
+	fit$call = match.call()  # store the function call
+	fit$glm = fit0 #  store the original object
+	fit$X = X # store the full design matrix
+	fit$Con = Con # store the constraint matrix
+	fit$pi_hat <- attr(Con, "pi_hat")  # story the proportions
+	fit$coefficients = beta_con # coefficient estimates
+	fit$cov.unscaled = cov.unscaled_con # covariance matrix
+	#fit$sigma = sigma_hat # estimated standard deviation
+	# fit$residuals # already there
+	#ADD: call
+
+	return(fit) # return the glmabc object
 }

--- a/R/lmabc.R
+++ b/R/lmabc.R
@@ -117,6 +117,7 @@ lmabc = function(formula, data, props = NULL){
 
 		fit0_centered <- lm(y ~ X)
 		beta_con <- coef(fit0_centered)
+		names(beta_con) <- c("(Intercept)", colnames(X))
 		cov.unscaled_con <- vcov(fit0_centered)
 		sigma_hat <- sigma(fit0_centered)
 		pi_hat <- props

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,7 +1,10 @@
+df_nrow <- 1000
+
 df <- mtcars |>
-	dplyr::slice_sample(n = 1000, replace = TRUE) |>
+	dplyr::slice_sample(n = df_nrow, replace = TRUE) |>
 	dplyr::mutate(dplyr::across(c(cyl, gear, carb), as.factor),
-								dplyr::across(c(cyl, gear, carb), ~ sample(., 1000, replace = TRUE)))
+								dplyr::across(c(cyl, gear, carb), ~ sample(., df_nrow, replace = TRUE)),
+								y_bin = rbinom(n = df_nrow, size = 1, prob = 0.75))
 
 f_contY_contX <- formula(mpg ~ hp + disp)
 f_contY_mixedX <- formula(mpg ~ disp + cyl)
@@ -10,3 +13,6 @@ f_contY_contX.contX <- formula(mpg ~ hp + disp + hp:disp)
 f_contY_contX.catX <- formula(mpg ~ disp + cyl + disp:cyl)
 f_contY_catX.catX <- formula(mpg ~ cyl + gear + cyl:gear)
 f_contY_all <- formula(mpg ~ hp + disp + cyl + gear + carb + hp:disp + disp:cyl + cyl:gear)
+
+g_contY_contX <- formula(y_bin ~ hp + disp)
+g_contY_catX <- formula(y_bin ~ cyl + gear)

--- a/tests/testthat/test-glmabc.R
+++ b/tests/testthat/test-glmabc.R
@@ -1,19 +1,19 @@
-test_that("lmabc has correct class in only continuous", {
+test_that("glmabc has correct class in only continuous", {
 	f <- f_contY_contX
-	expect_s3_class(lmabc(f, df), "lmabc")
+	expect_s3_class(glmabc(f, df), c("glmabc", "lmabc"))
 })
 
-test_that("lmabc does not have class 'lm' in only continuous", {
+test_that("glmabc does not have class 'lm' in only continuous", {
 	f <- f_contY_contX
-	expect_failure(expect_s3_class(lmabc(f, df), "lm"))
+	expect_failure(expect_s3_class(glmabc(f, df), "glm"))
 })
 
-test_that("lmabc has correct class with some categoricals", {
+test_that("glmabc has correct class with some categoricals", {
 	f <- f_contY_catX
-	expect_s3_class(lmabc(f, df), "lmabc")
+	expect_s3_class(glmabc(f, df), c("glmabc", "lmabc"))
 })
 
-test_that("lmabc does not have class 'lm' with some categoricals", {
+test_that("glmabc does not have class 'lm' with some categoricals", {
 	f <- f_contY_catX
-	expect_failure(expect_s3_class(lmabc(f, df), "lm"))
+	expect_failure(expect_s3_class(glmabc(f, df), "glm"))
 })

--- a/tests/testthat/test-glmabc.R
+++ b/tests/testthat/test-glmabc.R
@@ -1,19 +1,19 @@
 test_that("glmabc has correct class in only continuous", {
-	f <- f_contY_contX
-	expect_s3_class(glmabc(f, df), c("glmabc", "lmabc"))
+	f <- g_contY_contX
+	expect_s3_class(glmabc(f, family = "binomial", data = df), c("glmabc", "lmabc"))
 })
 
 test_that("glmabc does not have class 'lm' in only continuous", {
-	f <- f_contY_contX
-	expect_failure(expect_s3_class(glmabc(f, df), "glm"))
+	f <- g_contY_contX
+	expect_failure(expect_s3_class(glmabc(f, family = "binomial", data = df), "glm"))
 })
 
 test_that("glmabc has correct class with some categoricals", {
-	f <- f_contY_catX
-	expect_s3_class(glmabc(f, df), c("glmabc", "lmabc"))
+	f <- g_contY_catX
+	expect_s3_class(glmabc(f, family = "binomial", data = df), c("glmabc", "lmabc"))
 })
 
 test_that("glmabc does not have class 'lm' with some categoricals", {
-	f <- f_contY_catX
-	expect_failure(expect_s3_class(glmabc(f, df), "glm"))
+	f <- g_contY_catX
+	expect_failure(expect_s3_class(glmabc(f, family = "binomial", data = df), "glm"))
 })

--- a/tests/testthat/test-glmabc.R
+++ b/tests/testthat/test-glmabc.R
@@ -1,0 +1,19 @@
+test_that("lmabc has correct class in only continuous", {
+	f <- f_contY_contX
+	expect_s3_class(lmabc(f, df), "lmabc")
+})
+
+test_that("lmabc does not have class 'lm' in only continuous", {
+	f <- f_contY_contX
+	expect_failure(expect_s3_class(lmabc(f, df), "lm"))
+})
+
+test_that("lmabc has correct class with some categoricals", {
+	f <- f_contY_catX
+	expect_s3_class(lmabc(f, df), "lmabc")
+})
+
+test_that("lmabc does not have class 'lm' with some categoricals", {
+	f <- f_contY_catX
+	expect_failure(expect_s3_class(lmabc(f, df), "lm"))
+})

--- a/tests/testthat/test-glmabc.R
+++ b/tests/testthat/test-glmabc.R
@@ -17,3 +17,9 @@ test_that("glmabc does not have class 'glm' with some categoricals", {
 	f <- g_contY_catX
 	expect_failure(expect_s3_class(glmabc(f, family = "binomial", data = df), "glm"))
 })
+
+test_that("glmabc gives same non-intercept coefficients as glm with g_contY_contX", {
+	f <- g_contY_contX
+	expect_equal(coef(glmabc(f, family = "binomial", data = df))[-1],
+							 coef(glm(f, family = "binomial", data = df))[-1])
+})

--- a/tests/testthat/test-glmabc.R
+++ b/tests/testthat/test-glmabc.R
@@ -3,7 +3,7 @@ test_that("glmabc has correct class in only continuous", {
 	expect_s3_class(glmabc(f, family = "binomial", data = df), c("glmabc", "lmabc"))
 })
 
-test_that("glmabc does not have class 'lm' in only continuous", {
+test_that("glmabc does not have class 'glm' in only continuous", {
 	f <- g_contY_contX
 	expect_failure(expect_s3_class(glmabc(f, family = "binomial", data = df), "glm"))
 })
@@ -13,7 +13,7 @@ test_that("glmabc has correct class with some categoricals", {
 	expect_s3_class(glmabc(f, family = "binomial", data = df), c("glmabc", "lmabc"))
 })
 
-test_that("glmabc does not have class 'lm' with some categoricals", {
+test_that("glmabc does not have class 'glm' with some categoricals", {
 	f <- g_contY_catX
 	expect_failure(expect_s3_class(glmabc(f, family = "binomial", data = df), "glm"))
 })

--- a/tests/testthat/test-lmabc.R
+++ b/tests/testthat/test-lmabc.R
@@ -42,6 +42,12 @@ test_that("lmabc works with f_contY_contX", {
 	expect_equal(helper_fitted(f, df), lm(f, df)$fitted.values)
 })
 
+test_that("lmabc gives same non-intercept coefficients as lm with f_contY_contX", {
+	f <- f_contY_contX
+	expect_equal(coef(lmabc(f, data = df))[-1],
+							 coef(lm(f, data = df))[-1])
+})
+
 test_that("lmabc works with f_contY_mixedX", {
 	f <- f_contY_mixedX
 	expect_equal(helper_fitted(f, df), lm(f, df)$fitted.values)


### PR DESCRIPTION
Just like we did with lmabc a while ago, this pull request ensures that `glmabc` always returns an object of class "glmabc" — even if there are no categorical variables and we return the base `glm` fit.

Professor Kowal, do you have ideas for additional tests we should run on `glmabc`? `cv.penlmabc` is also untested at the moment. I suppose we can reimplement the `lmabc` test suite easily enough for `glmabc` using a binary outcome. Do we also want to consider other types of generalized linear models?